### PR TITLE
fix: Evaluate StorageClient only when UploadFile request comes through

### DIFF
--- a/worker/Services/GcsService.cs
+++ b/worker/Services/GcsService.cs
@@ -1,4 +1,5 @@
 ﻿using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Configuration;
 
 namespace hobio.worker.Services;
 
@@ -9,19 +10,39 @@ public interface IStorageService
 
 public class GcsService : IStorageService
 {
-    private readonly StorageClient _storageClient;
     private readonly string _bucketName;
+    private StorageClient? _storageClient;
+    private readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
 
     public GcsService(IConfiguration configuration)
     {
-        _storageClient = StorageClient.Create();
-        
         _bucketName = configuration["REPORTS_BUCKET_NAME"] ?? throw new ArgumentNullException("REPORTS_BUCKET_NAME not set");
+    }
+
+    private async Task<StorageClient> GetClientAsync()
+    {
+        if (_storageClient != null)
+            return _storageClient;
+
+        await _semaphore.WaitAsync();
+        try
+        {
+            if (_storageClient == null)
+            {
+                _storageClient = await StorageClient.CreateAsync();
+            }
+            return _storageClient;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
     }
 
     public async Task UploadFileAsync(byte[] content, string fileName, string contentType)
     {
+        var client = await GetClientAsync();
         using var stream = new MemoryStream(content);
-        await _storageClient.UploadObjectAsync(_bucketName, fileName, contentType, stream);
+        await client.UploadObjectAsync(_bucketName, fileName, contentType, stream);
     }
 }


### PR DESCRIPTION
**The Problem**: The exception System.InvalidOperationException: Your default credentials were not found points specifically to a known issue with how .NET reaches out to the Google Cloud Metadata Server synchronously when running inside Cloud Run.

Because StorageClient.Create() was being executed directly inside the constructor of GcsService, this resulted in "sync-over-async" blocking behavior on the thread pool. The constructor itself was being fired by MassTransit inside its message consumption scope logic exactly when the Consume thread handles an incoming worker task. This initial blocking thread starved the very async operation trying to fetch the Application Default Credentials from Cloud Run's HTTP metadata server (http://169.254.169.254), making it time out and erroneously throw "credentials not found."

The Solution: Refactor **_worker\Services\GcsService.cs_** to asynchronously lazily evaluate StorageClient using StorageClient.CreateAsync() only exactly when an UploadFileAsync request comes through.

A SemaphoreSlim provides thread safety ensuring we only do this once and never block MassTransit's concurrent message consumption.