### PR TITLE
Implement Job State Persistence in API

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -35,6 +35,10 @@ env:
   SECRET_NAME_PROD: rabbitmq-connection-string-prod
   BUCKET_NAME_DEV: hobio-nonprod-reports-ue1
   BUCKET_NAME_PROD: hobio-prod-reports-ue1
+  FIRESTORE_DATABASE_ID_DEV: hobio-dev-job-status
+  FIRESTORE_DATABASE_ID_PROD: hobio-prod-job-status
+  GOOGLE_CLOUD_PROJECT_DEV: hobio-nonprod
+  GOOGLE_CLOUD_PROJECT_PROD: hobio-prod
 
 jobs:
   configure:
@@ -45,6 +49,8 @@ jobs:
       vpc_connector: ${{ steps.vars.outputs.vpc_connector }}
       secret_name: ${{ steps.vars.outputs.secret_name }}
       bucket_name: ${{ steps.vars.outputs.bucket_name }}
+      firestore_database_id: ${{ steps.vars.outputs.firestore_database_id }}
+      google_cloud_project: ${{ steps.vars.outputs.google_cloud_project }}
     steps:
       - id: vars
         run: |
@@ -55,11 +61,15 @@ jobs:
             echo "vpc_connector=${{ env.VPC_CONNECTOR_PROD }}" >> "$GITHUB_OUTPUT"
             echo "secret_name=${{ env.SECRET_NAME_PROD }}" >> "$GITHUB_OUTPUT"
             echo "bucket_name=${{ env.BUCKET_NAME_PROD }}" >> "$GITHUB_OUTPUT"
+            echo "firestore_database_id=${{ env.FIRESTORE_DATABASE_ID_PROD }}" >> "$GITHUB_OUTPUT"
+            echo "google_cloud_project=${{ env.GOOGLE_CLOUD_PROJECT_PROD }}" >> "$GITHUB_OUTPUT"
           else
             echo "registry_env=nonprod" >> "$GITHUB_OUTPUT"
             echo "vpc_connector=${{ env.VPC_CONNECTOR_DEV }}" >> "$GITHUB_OUTPUT"
             echo "secret_name=${{ env.SECRET_NAME_DEV }}" >> "$GITHUB_OUTPUT"
             echo "bucket_name=${{ env.BUCKET_NAME_DEV }}" >> "$GITHUB_OUTPUT"
+            echo "firestore_database_id=${{ env.FIRESTORE_DATABASE_ID_DEV }}" >> "$GITHUB_OUTPUT"
+            echo "google_cloud_project=${{ env.GOOGLE_CLOUD_PROJECT_DEV }}" >> "$GITHUB_OUTPUT"
           fi
 
   build-api:
@@ -81,6 +91,7 @@ jobs:
       service: hobio-api-${{ needs.configure.outputs.registry_env }}
       vpc_connector: ${{ needs.configure.outputs.vpc_connector }}
       secrets: ConnectionStrings__RabbitMQ=${{ needs.configure.outputs.secret_name }}:latest
+      env_vars: FIRESTORE_DATABASE_ID=${{ needs.configure.outputs.firestore_database_id }},GOOGLE_CLOUD_PROJECT=${{ needs.configure.outputs.google_cloud_project }}
       region: ${{ github.event.inputs.region || 'us-east1' }}
     secrets: inherit
 
@@ -103,7 +114,7 @@ jobs:
       service: hobio-worker-${{ needs.configure.outputs.registry_env }}
       vpc_connector: ${{ needs.configure.outputs.vpc_connector }}
       secrets: ConnectionStrings__RabbitMQ=${{ needs.configure.outputs.secret_name }}:latest
-      env_vars: REPORTS_BUCKET_NAME=${{ needs.configure.outputs.bucket_name }}
+      env_vars: REPORTS_BUCKET_NAME=${{ needs.configure.outputs.bucket_name }},FIRESTORE_DATABASE_ID=${{ needs.configure.outputs.firestore_database_id }},GOOGLE_CLOUD_PROJECT=${{ needs.configure.outputs.google_cloud_project }}
       region: ${{ github.event.inputs.region || 'us-east1' }}
       no_cpu_throttling: true
     secrets: inherit

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   scan:
-    uses: nirojasmar/base-workflows/.github/workflows/sonar-scan.yml@feature/6-firestore-emulator
+    uses: nirojasmar/base-workflows/.github/workflows/sonar-scan.yml@v1
     with:
       project_key: "hobio"
       scanner_type: "dotnet"

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -8,11 +8,12 @@ on:
 
 jobs:
   scan:
-    uses: nirojasmar/base-workflows/.github/workflows/sonar-scan.yml@v1
+    uses: nirojasmar/base-workflows/.github/workflows/sonar-scan.yml@feature/6-firestore-emulator
     with:
       project_key: "hobio"
       scanner_type: "dotnet"
       test_settings_path: "tests/coverlet.runsettings"
+      enable_firestore_emulator: true
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SONAR_ORG: ${{ secrets.SONAR_ORG }}

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -42,15 +42,27 @@ public class ReportHandler
         Guid jobId,
         FirestoreDb firestoreDb)
     {
-        var docRef = firestoreDb.Collection("ReportJobs").Document(jobId.ToString());
-        var snapshot = await docRef.GetSnapshotAsync();
-        
-        if (!snapshot.Exists) 
+        if (firestoreDb == null)
         {
-            return Results.NotFound();
+            return Results.Problem("FirestoreDb is null or not configured", statusCode: 503);
         }
+
+        try
+        {
+            var docRef = firestoreDb.Collection("ReportJobs").Document(jobId.ToString());
+            var snapshot = await docRef.GetSnapshotAsync();
         
-        var job = snapshot.ConvertTo<ReportJob>();
-        return Results.Ok(new ReportStatusResponse(jobId, job.Status, job.StorageUrl, null));
+            if (!snapshot.Exists) 
+            {
+                return Results.NotFound();
+            }
+        
+            var job = snapshot.ConvertTo<ReportJob>();
+            return Results.Ok(new ReportStatusResponse(jobId, job.Status, job.StorageUrl, null));
+        }
+        catch (Exception ex)
+        {
+            return Results.Problem("Failed to get report status", statusCode: 500);
+        }
     }
 }

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -6,6 +6,8 @@ namespace hobio.api.Handlers;
 
 public class ReportHandler
 {
+    private const string ReportJobsCollection = "ReportJobs";
+    
     public static async Task<IResult> HandleReportRequest(
         ReportRequest request,
         IPublishEndpoint publishEndpoint,
@@ -27,7 +29,7 @@ public class ReportHandler
         
         if (firestoreDb != null)
         {
-            var docRef = firestoreDb.Collection("ReportJobs").Document(jobId.ToString());
+            var docRef = firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());
             await docRef.SetAsync(job);
         }
         
@@ -49,7 +51,7 @@ public class ReportHandler
 
         try
         {
-            var docRef = firestoreDb.Collection("ReportJobs").Document(jobId.ToString());
+            var docRef = firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());
             var snapshot = await docRef.GetSnapshotAsync();
         
             if (!snapshot.Exists) 

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -77,6 +77,7 @@ public class ReportHandler
         }
         catch (Exception ex)
         {
+            logger.LogError(ex, "Failed to get report status for job {JobId}", jobId);
             return Results.Problem("Failed to get report status", statusCode: 500);
         }
     }

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -27,13 +27,26 @@ public class ReportHandler
             Status = "Pending"
         };
         
+        DocumentReference? docRef = null;
         if (firestoreDb != null)
         {
-            var docRef = firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());
+            docRef = firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());
             await docRef.SetAsync(job);
         }
-        
-        await publishEndpoint.Publish(job);
+
+        try
+        {
+            await publishEndpoint.Publish(job);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to publish job {JobId}; removing stale Firestore document", jobId);
+            if (docRef != null)
+            {
+                await docRef.DeleteAsync();
+            }
+            throw;
+        }
         
         logger.LogInformation("Queued Job: {JobId}", jobId);
 

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -1,5 +1,6 @@
 using hobio.shared.Models;
 using MassTransit;
+using Google.Cloud.Firestore;
 
 namespace hobio.api.Handlers;
 
@@ -8,6 +9,7 @@ public class ReportHandler
     public static async Task<IResult> HandleReportRequest(
         ReportRequest request,
         IPublishEndpoint publishEndpoint,
+        FirestoreDb firestoreDb,
         ILogger<Program> logger)
     {
         var jobId = Guid.NewGuid();
@@ -19,13 +21,36 @@ public class ReportHandler
             Year = request.Year,
             Sources = request.Sources,
             CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow
+            UpdatedAt = DateTime.UtcNow,
+            Status = "Pending"
         };
+        
+        if (firestoreDb != null)
+        {
+            var docRef = firestoreDb.Collection("ReportJobs").Document(jobId.ToString());
+            await docRef.SetAsync(job);
+        }
         
         await publishEndpoint.Publish(job);
         
         logger.LogInformation("Queued Job: {JobId}", jobId);
 
         return Results.Accepted($"/api/report/status/{jobId}", new ReportResponse(jobId));
+    }
+
+    public static async Task<IResult> GetReportStatus(
+        Guid jobId,
+        FirestoreDb firestoreDb)
+    {
+        var docRef = firestoreDb.Collection("ReportJobs").Document(jobId.ToString());
+        var snapshot = await docRef.GetSnapshotAsync();
+        
+        if (!snapshot.Exists) 
+        {
+            return Results.NotFound();
+        }
+        
+        var job = snapshot.ConvertTo<ReportJob>();
+        return Results.Ok(new ReportStatusResponse(jobId, job.Status, job.StorageUrl, null));
     }
 }

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -30,8 +30,16 @@ public class ReportHandler
         DocumentReference? docRef = null;
         if (firestoreDb != null)
         {
-            docRef = firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());
-            await docRef.SetAsync(job);
+            try
+            {
+                docRef = firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());
+                await docRef.SetAsync(job);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to create document for job {JobId}", jobId);
+                return Results.Problem("Failed to create document for job", statusCode: 500);
+            }
         }
 
         try
@@ -45,7 +53,7 @@ public class ReportHandler
             {
                 await docRef.DeleteAsync();
             }
-            throw;
+            return Results.Problem("Failed to publish job", statusCode: 500);
         }
         
         logger.LogInformation("Queued Job: {JobId}", jobId);

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -55,10 +55,12 @@ public class ReportHandler
 
     public static async Task<IResult> GetReportStatus(
         Guid jobId,
-        FirestoreDb firestoreDb)
+        FirestoreDb firestoreDb,
+        ILogger<Program> logger)
     {
         if (firestoreDb == null)
         {
+            logger.LogError("FirestoreDb is null or not configured");
             return Results.Problem("FirestoreDb is null or not configured", statusCode: 503);
         }
 

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -17,7 +17,12 @@ public class Program
         // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
         builder.Services.AddOpenApi();
         
-        builder.Services.AddSingleton(FirestoreDb.Create(projectId));
+        var databaseId = builder.Configuration["FIRESTORE_DATABASE_ID"] ?? "(default)";
+        builder.Services.AddSingleton(new FirestoreDbBuilder 
+        { 
+            ProjectId = projectId, 
+            DatabaseId = databaseId 
+        }.Build());
         
         builder.Services.AddMassTransit(config =>
         {
@@ -46,6 +51,7 @@ public class Program
         
         app.MapGet("/", () => Results.Ok("Healthy"));
         app.MapPost("/api/report", ReportHandler.HandleReportRequest);
+        app.MapGet("/api/report/{jobId}", ReportHandler.GetReportStatus);
         
         await app.RunAsync();
     }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -51,7 +51,7 @@ public class Program
         
         app.MapGet("/", () => Results.Ok("Healthy"));
         app.MapPost("/api/report", ReportHandler.HandleReportRequest);
-        app.MapGet("/api/report/{jobId}", ReportHandler.GetReportStatus);
+        app.MapGet("/api/report/status/{jobId}", ReportHandler.GetReportStatus);
         
         await app.RunAsync();
     }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -4,16 +4,20 @@ using hobio.api.Handlers;
 using hobio.shared.Models;
 using MassTransit;
 using Microsoft.AspNetCore.Mvc;
+using Google.Cloud.Firestore;
 
 public class Program
 {
     public static async Task Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+        var projectId = builder.Configuration["GOOGLE_CLOUD_PROJECT"] ?? "hobio-nonprod";
         
         // Add services to the container.
         // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
         builder.Services.AddOpenApi();
+        
+        builder.Services.AddSingleton(FirestoreDb.Create(projectId));
         
         builder.Services.AddMassTransit(config =>
         {

--- a/api/hobio.api.csproj
+++ b/api/hobio.api.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Google.Cloud.Firestore" Version="4.2.0" />
         <PackageReference Include="MassTransit" Version="8.5.7" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.7" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2"/>

--- a/shared/Models/ReportJob.cs
+++ b/shared/Models/ReportJob.cs
@@ -1,17 +1,50 @@
-﻿namespace hobio.shared.Models;
+using Google.Cloud.Firestore;
 
+namespace hobio.shared.Models;
+
+[FirestoreData]
 public class ReportJob
 {
+    [FirestoreProperty(ConverterType = typeof(GuidConverter))]
     public Guid JobId { get; set; } = Guid.NewGuid();
+
+    [FirestoreProperty]
     public string UserId { get; set; }  = string.Empty;
+
+    [FirestoreProperty]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [FirestoreProperty]
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
+    [FirestoreProperty]
     public List<string> Sources { get; set; } = [];
     
+    [FirestoreProperty]
     public int Year { get; set; } = DateTime.Now.Year;
+
+    [FirestoreProperty]
     public int Month { get; set; } = DateTime.Now.Month;
+
+    [FirestoreProperty]
     public int Day { get; set; } = DateTime.Now.Day;
     
+    [FirestoreProperty]
     public string? Title { get; set; }
+
+    [FirestoreProperty]
+    public string Status { get; set; } = "Pending";
+
+    [FirestoreProperty]
+    public string? StorageUrl { get; set; }
+}
+
+public class GuidConverter : IFirestoreConverter<Guid>
+{
+    public object ToFirestore(Guid value) => value.ToString();
+    public Guid FromFirestore(object value) => value switch
+    {
+        string s when Guid.TryParse(s, out var g) => g,
+        _ => throw new ArgumentException($"Cannot convert {value} to Guid")
+    };
 }

--- a/shared/Models/ReportJob.cs
+++ b/shared/Models/ReportJob.cs
@@ -21,13 +21,13 @@ public class ReportJob
     public List<string> Sources { get; set; } = [];
     
     [FirestoreProperty]
-    public int Year { get; set; } = DateTime.Now.Year;
+    public int Year { get; set; } = DateTime.UtcNow.Year;
 
     [FirestoreProperty]
-    public int Month { get; set; } = DateTime.Now.Month;
+    public int Month { get; set; } = DateTime.UtcNow.Month;
 
     [FirestoreProperty]
-    public int Day { get; set; } = DateTime.Now.Day;
+    public int Day { get; set; } = DateTime.UtcNow.Day;
     
     [FirestoreProperty]
     public string? Title { get; set; }

--- a/shared/hobio.shared.csproj
+++ b/shared/hobio.shared.csproj
@@ -7,4 +7,8 @@
         <OutputType>Library</OutputType>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Google.Cloud.Firestore" Version="4.2.0" />
+    </ItemGroup>
+
 </Project>

--- a/tests/Consumers/ReportJobConsumerTests.cs
+++ b/tests/Consumers/ReportJobConsumerTests.cs
@@ -23,7 +23,8 @@ public class ReportJobConsumerTests
         // Arrange
         var logger = Substitute.For<ILogger<ReportJobConsumer>>();
         var storageService = Substitute.For<IStorageService>();
-        var consumer = new ReportJobConsumer(logger, storageService);
+        var jobStatusService = Substitute.For<IJobStatusService>();
+        var consumer = new ReportJobConsumer(logger, storageService, jobStatusService);
         var context = Substitute.For<ConsumeContext<ReportJob>>();
         
         var job = new ReportJob { JobId = Guid.NewGuid(), UserId = "user-123", Year = 2023, Sources = new List<string> { "Test Source" } };
@@ -33,42 +34,37 @@ public class ReportJobConsumerTests
         await consumer.Consume(context);
 
         // Assert
-        // Verify storage service was called
         await storageService.Received(1).UploadFileAsync(Arg.Any<byte[]>(), Arg.Any<string>(), "application/pdf");
+        await jobStatusService.Received(1).SetProcessingAsync(job.JobId);
+        await jobStatusService.Received(1).SetCompletedAsync(job.JobId, Arg.Any<string>());
+        await jobStatusService.DidNotReceive().SetFailedAsync(Arg.Any<Guid>());
     }
 
     [Fact]
-    public async Task Consume_ShouldLogAndRethrow_WhenExceptionOccurs()
+    public async Task Consume_ShouldSetFailedStatus_WhenExceptionOccurs()
     {
         // Arrange
         var logger = Substitute.For<ILogger<ReportJobConsumer>>();
         var storageService = Substitute.For<IStorageService>();
-        var consumer = new ReportJobConsumer(logger, storageService);
+        var jobStatusService = Substitute.For<IJobStatusService>();
+        var consumer = new ReportJobConsumer(logger, storageService, jobStatusService);
         var context = Substitute.For<ConsumeContext<ReportJob>>();
-        
-        var job = new ReportJob { JobId = Guid.NewGuid(), UserId = "user-failure" };
+
+        var job = new ReportJob { JobId = Guid.NewGuid(), UserId = "user-failure", Year = 2023, Sources = new List<string> { "Test Source" } };
         context.Message.Returns(job);
 
-        // Setup logger to throw on the second call (inside try block)
-        var callCount = 0;
-        logger.When(x => x.Log(
-                LogLevel.Information,
-                Arg.Any<EventId>(),
-                Arg.Any<object>(),
-                Arg.Any<Exception?>(),
-                Arg.Any<Func<object, Exception?, string>>()))
-            .Do(x => 
-            {
-                callCount++;
-                if (callCount == 2)
-                {
-                    throw new InvalidOperationException("Simulated Failure");
-                }
-            });
+        storageService
+            .UploadFileAsync(Arg.Any<byte[]>(), Arg.Any<string>(), Arg.Any<string>())
+            .ThrowsAsync(new InvalidOperationException("Simulated upload failure"));
 
         // Act & Assert
         var ex = await Assert.ThrowsAsync<ApplicationException>(() => consumer.Consume(context));
         Assert.Equal("Failed to generate report", ex.Message);
         Assert.IsType<InvalidOperationException>(ex.InnerException);
+
+        await jobStatusService.Received(1).SetProcessingAsync(job.JobId);
+        await jobStatusService.Received(1).SetFailedAsync(job.JobId);
+        await jobStatusService.DidNotReceive().SetCompletedAsync(Arg.Any<Guid>(), Arg.Any<string>());
     }
 }
+

--- a/tests/Consumers/ReportJobConsumerTests.cs
+++ b/tests/Consumers/ReportJobConsumerTests.cs
@@ -58,7 +58,7 @@ public class ReportJobConsumerTests
             .ThrowsAsync(new InvalidOperationException("Simulated upload failure"));
 
         // Act & Assert
-        var ex = await Assert.ThrowsAsync<ApplicationException>(() => consumer.Consume(context));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => consumer.Consume(context));
         Assert.Equal("Failed to generate report", ex.Message);
         Assert.IsType<InvalidOperationException>(ex.InnerException);
 

--- a/tests/Handlers/ReportHandlerFirestoreTests.cs
+++ b/tests/Handlers/ReportHandlerFirestoreTests.cs
@@ -1,0 +1,159 @@
+using Google.Cloud.Firestore;
+using hobio.api.Handlers;
+using hobio.shared.Models;
+using MassTransit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace hobio.tests.Handlers;
+
+/// <summary>
+/// Integration tests for the Firestore persistence path in <see cref="ReportHandler"/>.
+///
+/// These tests require the Firestore emulator to be running and
+/// <c>FIRESTORE_EMULATOR_HOST</c> to be set (e.g. "localhost:8080").
+/// They are automatically <b>skipped</b> when the environment variable is absent,
+/// so they never fail on developer machines that don't have the emulator.
+///
+/// To run locally:
+///   gcloud beta emulators firestore start --host-port=localhost:8787
+///   $env:FIRESTORE_EMULATOR_HOST = "localhost:8787"
+///   dotnet test --filter "FullyQualifiedName~ReportHandlerFirestoreTests"
+/// </summary>
+public class ReportHandlerFirestoreTests : IAsyncLifetime
+{
+    private const string ProjectId = "hobio-test";
+    private const string ReportJobsCollection = "ReportJobs";
+
+    private FirestoreDb? _db;
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    public async Task InitializeAsync()
+    {
+        Skip.If(
+            string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FIRESTORE_EMULATOR_HOST")),
+            "Skipped: FIRESTORE_EMULATOR_HOST is not set. Start the Firestore emulator to run these tests.");
+
+        _db = await new FirestoreDbBuilder
+        {
+            ProjectId = ProjectId,
+            EmulatorDetection = Google.Api.Gax.EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private FirestoreDb Db => _db!; // safe after InitializeAsync guard
+
+    private (IPublishEndpoint, ILogger<hobio.api.Program>) CreateInfra()
+    {
+        var publishEndpoint = Substitute.For<IPublishEndpoint>();
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        return (publishEndpoint, logger);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// HandleReportRequest with a real FirestoreDb should write a Pending document
+    /// whose fields match the request.
+    /// </summary>
+    [SkippableFact]
+    public async Task HandleReportRequest_WithFirestoreDb_WritesJobDocument()
+    {
+        // Arrange
+        var (publishEndpoint, logger) = CreateInfra();
+        var request = new ReportRequest(2024, new List<string> { "Steam", "LastFm" });
+
+        // Act
+        var result = await ReportHandler.HandleReportRequest(request, publishEndpoint, Db, logger);
+
+        // Assert – HTTP response
+        var accepted = Assert.IsType<Accepted<ReportResponse>>(result);
+        var jobId = accepted.Value!.JobId;
+        Assert.NotEqual(Guid.Empty, jobId);
+        Assert.StartsWith("/api/report/status/", accepted.Location);
+
+        // Assert – Firestore document was written
+        var docRef = Db.Collection(ReportJobsCollection).Document(jobId.ToString());
+        var snapshot = await docRef.GetSnapshotAsync();
+
+        Assert.True(snapshot.Exists, "ReportJob document should exist in Firestore after HandleReportRequest");
+
+        var stored = snapshot.ConvertTo<ReportJob>();
+        Assert.Equal(jobId, stored.JobId);
+        Assert.Equal("user-123", stored.UserId);
+        Assert.Equal(2024, stored.Year);
+        Assert.Equal(new List<string> { "Steam", "LastFm" }, stored.Sources);
+        Assert.Equal("Pending", stored.Status);
+
+        // clean up
+        await docRef.DeleteAsync();
+    }
+
+    /// <summary>
+    /// GetReportStatus for a job that exists in Firestore should return 200 OK
+    /// with the correct status and jobId.
+    /// </summary>
+    [SkippableFact]
+    public async Task GetReportStatus_ExistingJob_ReturnsOkWithStatus()
+    {
+        // Arrange – seed a known document
+        var jobId = Guid.NewGuid();
+        var docRef = Db.Collection(ReportJobsCollection).Document(jobId.ToString());
+
+        var job = new ReportJob
+        {
+            JobId = jobId,
+            UserId = "user-123",
+            Year = 2024,
+            Sources = new List<string> { "Steam" },
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Status = "Completed",
+            StorageUrl = "https://storage.example.com/report.pdf"
+        };
+        await docRef.SetAsync(job);
+
+        // Act
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        var result = await ReportHandler.GetReportStatus(jobId, Db, logger);
+
+        // Assert
+        var ok = Assert.IsType<Ok<ReportStatusResponse>>(result);
+        Assert.Equal(jobId, ok.Value!.JobId);
+        Assert.Equal("Completed", ok.Value.Status);
+        Assert.Equal("https://storage.example.com/report.pdf", ok.Value.DownloadUrl);
+
+        // clean up
+        await docRef.DeleteAsync();
+    }
+
+    /// <summary>
+    /// GetReportStatus for a job that does NOT exist in Firestore should return 404.
+    /// </summary>
+    [SkippableFact]
+    public async Task GetReportStatus_MissingJob_ReturnsNotFound()
+    {
+        // Arrange – use a random ID that was never written
+        var missingJobId = Guid.NewGuid();
+
+        // Act
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        var result = await ReportHandler.GetReportStatus(missingJobId, Db, logger);
+
+        // Assert
+        Assert.IsType<NotFound>(result);
+    }
+}

--- a/tests/Handlers/ReportHandlerTests.cs
+++ b/tests/Handlers/ReportHandlerTests.cs
@@ -16,10 +16,11 @@ public class ReportHandlerTests
         // Arrange
         var publishEndpoint = Substitute.For<IPublishEndpoint>();
         var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        Google.Cloud.Firestore.FirestoreDb firestoreDb = null!;
         var request = new ReportRequest(2023, new List<string> { "Steam", "LastFm" });
 
         // Act
-        var result = await ReportHandler.HandleReportRequest(request, publishEndpoint, logger);
+        var result = await ReportHandler.HandleReportRequest(request, publishEndpoint, firestoreDb, logger);
 
         // Assert
         await publishEndpoint.Received(1).Publish(Arg.Is<ReportJob>(j => 

--- a/tests/Handlers/ReportHandlerTests.cs
+++ b/tests/Handlers/ReportHandlerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 namespace hobio.tests.Handlers;
 
@@ -31,5 +32,38 @@ public class ReportHandlerTests
         var acceptedResult = Assert.IsType<Accepted<ReportResponse>>(result);
         Assert.StartsWith("/api/report/status/", acceptedResult.Location);
         Assert.NotEqual(Guid.Empty, acceptedResult.Value.JobId);
+    }
+
+    [Fact]
+    public async Task HandleReportRequest_WhenPublishFails_ReturnsProblem()
+    {
+        // Arrange
+        var request = new ReportRequest(2024, new List<string> { "Steam" });
+        var publishEndpoint = Substitute.For<IPublishEndpoint>();
+        publishEndpoint.Publish(Arg.Any<ReportJob>()).ThrowsAsync(new Exception("Simulated publish failure"));
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+
+        // Act
+        var result = await ReportHandler.HandleReportRequest(request, publishEndpoint, null, logger);
+
+        // Assert
+        var problem = Assert.IsType<ProblemHttpResult>(result);
+        Assert.Equal(500, problem.StatusCode);
+        Assert.Equal("Failed to publish job", problem.ProblemDetails.Detail);
+    }
+
+    [Fact]
+    public async Task GetReportStatus_WhenFirestoreIsNull_ReturnsServiceUnavailable()
+    {
+        // Arrange
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+
+        // Act
+        var result = await ReportHandler.GetReportStatus(Guid.NewGuid(), null, logger);
+
+        // Assert
+        var problem = Assert.IsType<ProblemHttpResult>(result);
+        Assert.Equal(503, problem.StatusCode);
+        Assert.Equal("FirestoreDb is null or not configured", problem.ProblemDetails.Detail);
     }
 }

--- a/tests/Services/JobStatusServiceFirestoreTests.cs
+++ b/tests/Services/JobStatusServiceFirestoreTests.cs
@@ -1,0 +1,100 @@
+using Google.Cloud.Firestore;
+using hobio.shared.Models;
+using hobio.worker.Services;
+using Xunit;
+
+namespace hobio.tests.Services;
+
+/// <summary>
+/// Integration tests for the Firestore persistence path in <see cref="JobStatusService"/>.
+///
+/// These tests require the Firestore emulator to be running and
+/// <c>FIRESTORE_EMULATOR_HOST</c> to be set (e.g. "localhost:8080").
+/// They are automatically <b>skipped</b> when the environment variable is absent.
+/// </summary>
+public class JobStatusServiceFirestoreTests : IAsyncLifetime
+{
+    private const string ProjectId = "hobio-test-worker";
+    private const string ReportJobsCollection = "ReportJobs";
+
+    private FirestoreDb? _db;
+
+    public async Task InitializeAsync()
+    {
+        Skip.If(
+            string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FIRESTORE_EMULATOR_HOST")),
+            "Skipped: FIRESTORE_EMULATOR_HOST is not set. Start the Firestore emulator to run these tests.");
+
+        _db = await new FirestoreDbBuilder
+        {
+            ProjectId = ProjectId,
+            EmulatorDetection = Google.Api.Gax.EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    private FirestoreDb Db => _db!;
+
+    [SkippableFact]
+    public async Task SetProcessingAsync_UpdatesStatusToProcessing()
+    {
+        // Arrange
+        var jobId = Guid.NewGuid();
+        var docRef = Db.Collection(ReportJobsCollection).Document(jobId.ToString());
+        await docRef.SetAsync(new { Status = "Pending", UpdatedAt = DateTime.UtcNow });
+        var service = new JobStatusService(Db);
+
+        // Act
+        await service.SetProcessingAsync(jobId);
+
+        // Assert
+        var snapshot = await docRef.GetSnapshotAsync();
+        var status = snapshot.GetValue<string>("Status");
+        Assert.Equal("Processing", status);
+        
+        await docRef.DeleteAsync();
+    }
+
+    [SkippableFact]
+    public async Task SetCompletedAsync_UpdatesStatusAndStorageUrl()
+    {
+        // Arrange
+        var jobId = Guid.NewGuid();
+        var docRef = Db.Collection(ReportJobsCollection).Document(jobId.ToString());
+        await docRef.SetAsync(new { Status = "Processing", UpdatedAt = DateTime.UtcNow });
+        var service = new JobStatusService(Db);
+
+        // Act
+        await service.SetCompletedAsync(jobId, "http://example.com/test.pdf");
+
+        // Assert
+        var snapshot = await docRef.GetSnapshotAsync();
+        var status = snapshot.GetValue<string>("Status");
+        var url = snapshot.GetValue<string>("StorageUrl");
+        Assert.Equal("Completed", status);
+        Assert.Equal("http://example.com/test.pdf", url);
+        
+        await docRef.DeleteAsync();
+    }
+
+    [SkippableFact]
+    public async Task SetFailedAsync_UpdatesStatusToFailed()
+    {
+        // Arrange
+        var jobId = Guid.NewGuid();
+        var docRef = Db.Collection(ReportJobsCollection).Document(jobId.ToString());
+        await docRef.SetAsync(new { Status = "Processing", UpdatedAt = DateTime.UtcNow });
+        var service = new JobStatusService(Db);
+
+        // Act
+        await service.SetFailedAsync(jobId);
+
+        // Assert
+        var snapshot = await docRef.GetSnapshotAsync();
+        var status = snapshot.GetValue<string>("Status");
+        Assert.Equal("Failed", status);
+        
+        await docRef.DeleteAsync();
+    }
+}

--- a/tests/hobio.tests.csproj
+++ b/tests/hobio.tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
@@ -11,6 +11,7 @@
         <PackageReference Include="coverlet.collector" Version="6.0.4"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/>
         <PackageReference Include="NSubstitute" Version="5.3.0" />
+        <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/>
     </ItemGroup>

--- a/worker/Consumers/ReportJobConsumer.cs
+++ b/worker/Consumers/ReportJobConsumer.cs
@@ -49,7 +49,7 @@ public class ReportJobConsumer : IConsumer<ReportJob>
             await _jobStatusService.SetFailedAsync(job.JobId);
             _logger.LogInformation("Job {JobId} status set to Failed", job.JobId);
 
-            throw new ApplicationException("Failed to generate report", e);
+            throw new InvalidOperationException("Failed to generate report", e);
         }
     }
-}
+}

--- a/worker/Consumers/ReportJobConsumer.cs
+++ b/worker/Consumers/ReportJobConsumer.cs
@@ -1,4 +1,4 @@
-﻿using hobio.shared.Models;
+using hobio.shared.Models;
 using hobio.worker.PdfLayouts;
 using MassTransit;
 using Microsoft.Extensions.Logging;
@@ -10,19 +10,24 @@ namespace hobio.worker.Consumers;
 public class ReportJobConsumer : IConsumer<ReportJob>
 {
     private readonly IStorageService _storageService;
+    private readonly IJobStatusService _jobStatusService;
     private readonly ILogger<ReportJobConsumer> _logger;
     
-    public ReportJobConsumer(ILogger<ReportJobConsumer> logger, IStorageService storageService)
+    public ReportJobConsumer(ILogger<ReportJobConsumer> logger, IStorageService storageService, IJobStatusService jobStatusService)
     {
         _logger = logger;
         _storageService = storageService;
+        _jobStatusService = jobStatusService;
     }
 
     public async Task Consume(ConsumeContext<ReportJob> context)
     {
         var job = context.Message;
-        _logger.LogInformation("Received Job: {JobId} for  User: {UserId}", job.JobId, job.UserId);
-        
+        _logger.LogInformation("Received Job: {JobId} for User: {UserId}", job.JobId, job.UserId);
+
+        await _jobStatusService.SetProcessingAsync(job.JobId);
+        _logger.LogInformation("Job {JobId} status set to Processing", job.JobId);
+
         var document = new ReportDocument(context.Message);
 
         try
@@ -33,11 +38,18 @@ public class ReportJobConsumer : IConsumer<ReportJob>
             
             await _storageService.UploadFileAsync(pdfBytes, fileName, "application/pdf");
             _logger.LogInformation("Report Generated Successfully: {FileName}", fileName);
+
+            await _jobStatusService.SetCompletedAsync(job.JobId, fileName);
+            _logger.LogInformation("Job {JobId} status set to Completed, StorageUrl: {FileName}", job.JobId, fileName);
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Error Generating Report");
+            _logger.LogError(e, "Error Generating Report for Job {JobId}", job.JobId);
+
+            await _jobStatusService.SetFailedAsync(job.JobId);
+            _logger.LogInformation("Job {JobId} status set to Failed", job.JobId);
+
             throw new ApplicationException("Failed to generate report", e);
         }
     }
-}
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -12,8 +12,7 @@ COPY ["shared/hobio.shared.csproj", "shared/"]
 RUN dotnet restore "worker/hobio.worker.csproj"
 
 COPY . .
-WORKDIR "/src/worker"
-RUN find /src/worker -name "*.cs" | sort 
+WORKDIR "/src/worker" 
 RUN dotnet build "hobio.worker.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -13,6 +13,7 @@ RUN dotnet restore "worker/hobio.worker.csproj"
 
 COPY . .
 WORKDIR "/src/worker"
+RUN find /src/worker -name "*.cs" | sort 
 RUN dotnet build "hobio.worker.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish

--- a/worker/Program.cs
+++ b/worker/Program.cs
@@ -2,6 +2,7 @@ namespace hobio.worker;
 
 using hobio.worker.Consumers;
 using hobio.worker.Services;
+using Google.Cloud.Firestore;
 using MassTransit;
 using QuestPDF.Infrastructure;
 using Microsoft.AspNetCore.Builder;
@@ -13,12 +14,14 @@ public class Program
     {
         QuestPDF.Settings.License = LicenseType.Community;
         var builder = WebApplication.CreateBuilder(args);
+        var projectId = builder.Configuration["GOOGLE_CLOUD_PROJECT"] ?? "hobio-nonprod";
         
-        // Eagerly fetch Google Cloud Credentials during startup (unthrottled CPU boost phase)
         Console.WriteLine("[Boot] Fetching Application Default Credentials...");
         var googleCredential = await Google.Apis.Auth.OAuth2.GoogleCredential.GetApplicationDefaultAsync();
         builder.Services.AddSingleton(googleCredential);
         Console.WriteLine("[Boot] Successfully cached Application Default Credentials in DI.");
+        
+        builder.Services.AddSingleton(FirestoreDb.Create(projectId));
         
         builder.Services.AddSingleton<IStorageService, GcsService>();
         

--- a/worker/Program.cs
+++ b/worker/Program.cs
@@ -29,6 +29,8 @@ public class Program
         }.Build());
         
         builder.Services.AddSingleton<IStorageService, GcsService>();
+        builder.Services.AddSingleton<IJobStatusService, JobStatusService>();
+
         
         builder.Services.AddMassTransit(config =>
         {

--- a/worker/Program.cs
+++ b/worker/Program.cs
@@ -21,7 +21,12 @@ public class Program
         builder.Services.AddSingleton(googleCredential);
         Console.WriteLine("[Boot] Successfully cached Application Default Credentials in DI.");
         
-        builder.Services.AddSingleton(FirestoreDb.Create(projectId));
+        var databaseId = builder.Configuration["FIRESTORE_DATABASE_ID"] ?? "hobio-dev-job-status";
+        builder.Services.AddSingleton(new FirestoreDbBuilder 
+        { 
+            ProjectId = projectId, 
+            DatabaseId = databaseId 
+        }.Build());
         
         builder.Services.AddSingleton<IStorageService, GcsService>();
         

--- a/worker/Services/JobStatusService.cs
+++ b/worker/Services/JobStatusService.cs
@@ -1,0 +1,47 @@
+using Google.Cloud.Firestore;
+
+namespace hobio.worker.Services;
+
+public interface IJobStatusService
+{
+    Task SetProcessingAsync(Guid jobId);
+    Task SetCompletedAsync(Guid jobId, string storageUrl);
+    Task SetFailedAsync(Guid jobId);
+}
+
+public class JobStatusService : IJobStatusService
+{
+    private const string ReportJobsCollection = "ReportJobs";
+
+    private readonly FirestoreDb _firestoreDb;
+
+    public JobStatusService(FirestoreDb firestoreDb)
+    {
+        _firestoreDb = firestoreDb;
+    }
+
+    public Task SetProcessingAsync(Guid jobId) =>
+        GetDocRef(jobId).UpdateAsync(new Dictionary<string, object>
+        {
+            { "Status", "Processing" },
+            { "UpdatedAt", DateTime.UtcNow }
+        });
+
+    public Task SetCompletedAsync(Guid jobId, string storageUrl) =>
+        GetDocRef(jobId).UpdateAsync(new Dictionary<string, object>
+        {
+            { "Status", "Completed" },
+            { "StorageUrl", storageUrl },
+            { "UpdatedAt", DateTime.UtcNow }
+        });
+
+    public Task SetFailedAsync(Guid jobId) =>
+        GetDocRef(jobId).UpdateAsync(new Dictionary<string, object>
+        {
+            { "Status", "Failed" },
+            { "UpdatedAt", DateTime.UtcNow }
+        });
+
+    private DocumentReference GetDocRef(Guid jobId) =>
+        _firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());
+}

--- a/worker/Services/JobStatusService.cs
+++ b/worker/Services/JobStatusService.cs
@@ -21,26 +21,26 @@ public class JobStatusService : IJobStatusService
     }
 
     public Task SetProcessingAsync(Guid jobId) =>
-        GetDocRef(jobId).UpdateAsync(new Dictionary<string, object>
+        GetDocRef(jobId).SetAsync(new Dictionary<string, object>
         {
             { "Status", "Processing" },
             { "UpdatedAt", DateTime.UtcNow }
-        });
+        }, SetOptions.MergeAll);
 
     public Task SetCompletedAsync(Guid jobId, string storageUrl) =>
-        GetDocRef(jobId).UpdateAsync(new Dictionary<string, object>
+        GetDocRef(jobId).SetAsync(new Dictionary<string, object>
         {
             { "Status", "Completed" },
             { "StorageUrl", storageUrl },
             { "UpdatedAt", DateTime.UtcNow }
-        });
+        }, SetOptions.MergeAll);
 
     public Task SetFailedAsync(Guid jobId) =>
-        GetDocRef(jobId).UpdateAsync(new Dictionary<string, object>
+        GetDocRef(jobId).SetAsync(new Dictionary<string, object>
         {
             { "Status", "Failed" },
             { "UpdatedAt", DateTime.UtcNow }
-        });
+        }, SetOptions.MergeAll);
 
     private DocumentReference GetDocRef(Guid jobId) =>
         _firestoreDb.Collection(ReportJobsCollection).Document(jobId.ToString());

--- a/worker/hobio.worker.csproj
+++ b/worker/hobio.worker.csproj
@@ -9,6 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Google.Cloud.Firestore" Version="4.2.0" />
         <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
         <PackageReference Include="MassTransit" Version="8.5.7" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.7" />


### PR DESCRIPTION
Issue: #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs now start as "Pending", are persisted for reliable tracking, and a GET /api/report/status/{jobId} endpoint exposes job status and download URL.
  * Worker updates job lifecycle (Processing → Completed/Failed) during processing.

* **Bug Fixes**
  * Added cleanup to remove created job records if publishing fails; handlers return appropriate errors when persistence or publish fails.

* **Tests**
  * Added unit and integration tests for Firestore-backed persistence, status checks, and failure scenarios.

* **Chores**
  * Added Google Cloud Firestore support and CI workflow env wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->