### PR TITLE
Generate GCS Signed URLs for Secure Downloads

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -91,7 +91,7 @@ jobs:
       service: hobio-api-${{ needs.configure.outputs.registry_env }}
       vpc_connector: ${{ needs.configure.outputs.vpc_connector }}
       secrets: ConnectionStrings__RabbitMQ=${{ needs.configure.outputs.secret_name }}:latest
-      env_vars: FIRESTORE_DATABASE_ID=${{ needs.configure.outputs.firestore_database_id }},GOOGLE_CLOUD_PROJECT=${{ needs.configure.outputs.google_cloud_project }}
+      env_vars: REPORTS_BUCKET_NAME=${{ needs.configure.outputs.bucket_name }},FIRESTORE_DATABASE_ID=${{ needs.configure.outputs.firestore_database_id }},GOOGLE_CLOUD_PROJECT=${{ needs.configure.outputs.google_cloud_project }}
       region: ${{ github.event.inputs.region || 'us-east1' }}
     secrets: inherit
 

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -89,10 +89,11 @@ public class ReportHandler
             string? downloadUrl = null;
             if (job.Status == "Completed" && !string.IsNullOrEmpty(job.StorageUrl))
             {
+                var objectName = Uri.TryCreate(job.StorageUrl, UriKind.Absolute, out var storageUri)
+                    ? storageUri.AbsolutePath.TrimStart('/')
+                    : job.StorageUrl;
                 try
                 {
-                    var storageUri = new Uri(job.StorageUrl);
-                    var objectName = storageUri.AbsolutePath.TrimStart('/');
                     downloadUrl = await storageService.GetSignedDownloadUrlAsync(objectName, TimeSpan.FromMinutes(15));
                 }
                 catch (Exception ex)

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -86,17 +86,18 @@ public class ReportHandler
         
             var job = snapshot.ConvertTo<ReportJob>();
             
-            string? downloadUrl = job.StorageUrl;
+            string? downloadUrl = null;
             if (job.Status == "Completed" && !string.IsNullOrEmpty(job.StorageUrl))
             {
                 try
                 {
-                    downloadUrl = await storageService.GetSignedDownloadUrlAsync(job.StorageUrl, TimeSpan.FromMinutes(15));
+                    var storageUri = new Uri(job.StorageUrl);
+                    var objectName = storageUri.AbsolutePath.TrimStart('/');
+                    downloadUrl = await storageService.GetSignedDownloadUrlAsync(objectName, TimeSpan.FromMinutes(15));
                 }
                 catch (Exception ex)
                 {
                     logger.LogWarning(ex, "Failed to generate signed URL for job {JobId}", jobId);
-                    // Fall back to returning the raw URL if signing fails.
                 }
             }
             

--- a/api/Handlers/ReportHandler.cs
+++ b/api/Handlers/ReportHandler.cs
@@ -1,6 +1,7 @@
 using hobio.shared.Models;
 using MassTransit;
 using Google.Cloud.Firestore;
+using hobio.api.Services;
 
 namespace hobio.api.Handlers;
 
@@ -64,6 +65,7 @@ public class ReportHandler
     public static async Task<IResult> GetReportStatus(
         Guid jobId,
         FirestoreDb firestoreDb,
+        IStorageService storageService,
         ILogger<Program> logger)
     {
         if (firestoreDb == null)
@@ -83,7 +85,22 @@ public class ReportHandler
             }
         
             var job = snapshot.ConvertTo<ReportJob>();
-            return Results.Ok(new ReportStatusResponse(jobId, job.Status, job.StorageUrl, null));
+            
+            string? downloadUrl = job.StorageUrl;
+            if (job.Status == "Completed" && !string.IsNullOrEmpty(job.StorageUrl))
+            {
+                try
+                {
+                    downloadUrl = await storageService.GetSignedDownloadUrlAsync(job.StorageUrl, TimeSpan.FromMinutes(15));
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to generate signed URL for job {JobId}", jobId);
+                    // Fall back to returning the raw URL if signing fails.
+                }
+            }
+            
+            return Results.Ok(new ReportStatusResponse(jobId, job.Status, downloadUrl, null));
         }
         catch (Exception ex)
         {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -5,6 +5,7 @@ using hobio.shared.Models;
 using MassTransit;
 using Microsoft.AspNetCore.Mvc;
 using Google.Cloud.Firestore;
+using hobio.api.Services;
 
 public class Program
 {
@@ -23,6 +24,13 @@ public class Program
             ProjectId = projectId, 
             DatabaseId = databaseId 
         }.Build());
+        
+        Console.WriteLine("[Boot] Fetching Application Default Credentials...");
+        var googleCredential = await Google.Apis.Auth.OAuth2.GoogleCredential.GetApplicationDefaultAsync();
+        builder.Services.AddSingleton(googleCredential);
+        Console.WriteLine("[Boot] Successfully cached Application Default Credentials in DI.");
+        
+        builder.Services.AddSingleton<IStorageService, StorageService>();
         
         builder.Services.AddMassTransit(config =>
         {

--- a/api/Services/IStorageService.cs
+++ b/api/Services/IStorageService.cs
@@ -1,0 +1,6 @@
+namespace hobio.api.Services;
+
+public interface IStorageService
+{
+    Task<string> GetSignedDownloadUrlAsync(string fileName, TimeSpan duration);
+}

--- a/api/Services/IStorageService.cs
+++ b/api/Services/IStorageService.cs
@@ -2,5 +2,5 @@ namespace hobio.api.Services;
 
 public interface IStorageService
 {
-    Task<string> GetSignedDownloadUrlAsync(string fileName, TimeSpan duration);
+    Task<string> GetSignedDownloadUrlAsync(string objectName, TimeSpan duration);
 }

--- a/api/Services/StorageService.cs
+++ b/api/Services/StorageService.cs
@@ -14,12 +14,12 @@ public class StorageService : IStorageService
         _bucketName = configuration["REPORTS_BUCKET_NAME"] ?? throw new ArgumentNullException("REPORTS_BUCKET_NAME not set");
     }
 
-    public async Task<string> GetSignedDownloadUrlAsync(string fileName, TimeSpan duration)
+    public async Task<string> GetSignedDownloadUrlAsync(string objectName, TimeSpan duration)
     {
         var signer = UrlSigner.FromCredential(_credential);
         return await signer.SignAsync(
             _bucketName,
-            fileName,
+            objectName,
             duration,
             HttpMethod.Get);
     }

--- a/api/Services/StorageService.cs
+++ b/api/Services/StorageService.cs
@@ -1,0 +1,26 @@
+using Google.Cloud.Storage.V1;
+using Microsoft.Extensions.Configuration;
+
+namespace hobio.api.Services;
+
+public class StorageService : IStorageService
+{
+    private readonly string _bucketName;
+    private readonly Google.Apis.Auth.OAuth2.GoogleCredential _credential;
+
+    public StorageService(IConfiguration configuration, Google.Apis.Auth.OAuth2.GoogleCredential credential)
+    {
+        _credential = credential;
+        _bucketName = configuration["REPORTS_BUCKET_NAME"] ?? throw new ArgumentNullException("REPORTS_BUCKET_NAME not set");
+    }
+
+    public async Task<string> GetSignedDownloadUrlAsync(string fileName, TimeSpan duration)
+    {
+        var signer = UrlSigner.FromCredential(_credential);
+        return await signer.SignAsync(
+            _bucketName,
+            fileName,
+            duration,
+            HttpMethod.Get);
+    }
+}

--- a/api/hobio.api.csproj
+++ b/api/hobio.api.csproj
@@ -9,9 +9,10 @@
 
     <ItemGroup>
         <PackageReference Include="Google.Cloud.Firestore" Version="4.2.0" />
+        <PackageReference Include="Google.Cloud.Storage.V1" Version="4.14.0" />
         <PackageReference Include="MassTransit" Version="8.5.7" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.7" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Handlers/ReportHandlerEdgeCaseTests.cs
+++ b/tests/Handlers/ReportHandlerEdgeCaseTests.cs
@@ -1,0 +1,193 @@
+using Google.Cloud.Firestore;
+using hobio.api.Handlers;
+using hobio.shared.Models;
+using MassTransit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace hobio.tests.Handlers;
+
+/// <summary>
+/// Unit tests for edge-case branches in <see cref="ReportHandler"/> that do
+/// not require a live Firestore connection (FirestoreDb is always null or
+/// substituted via the Firestore emulator path covered in
+/// ReportHandlerFirestoreTests).
+/// </summary>
+public class ReportHandlerEdgeCaseTests
+{
+    // -------------------------------------------------------------------------
+    // HandleReportRequest edge cases
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// When Firestore is null the handler should still publish the job and
+    /// return Accepted (existing test covers this, but exercising the
+    /// null-firestoreDb fast-path explicitly here for clarity).
+    /// </summary>
+    [Fact]
+    public async Task HandleReportRequest_NullFirestore_StillPublishesAndReturnsAccepted()
+    {
+        var publishEndpoint = Substitute.For<IPublishEndpoint>();
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        var request = new ReportRequest(2025, new List<string> { "Steam" });
+
+        var result = await ReportHandler.HandleReportRequest(request, publishEndpoint, null!, logger);
+
+        var accepted = Assert.IsType<Accepted<ReportResponse>>(result);
+        Assert.NotEqual(Guid.Empty, accepted.Value!.JobId);
+        await publishEndpoint.Received(1).Publish(Arg.Any<ReportJob>());
+    }
+
+    // -------------------------------------------------------------------------
+    // GetReportStatus edge cases
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// When the job's Status is "Completed" but StorageUrl is null,
+    /// the handler must NOT call GetSignedDownloadUrlAsync and should return
+    /// Ok with a null DownloadUrl.
+    /// </summary>
+    [Fact]
+    public async Task GetReportStatus_CompletedJobWithNullStorageUrl_ReturnsOkWithNullDownloadUrl()
+    {
+        // Arrange – seed a "Completed" job that has no StorageUrl yet
+        // We exercise the null-firestoreDb guard path we already have a test for,
+        // but we still need to hit the branch inside the try block.
+        // Use the Firestore emulator when available; skip otherwise.
+        Skip.If(
+            string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FIRESTORE_EMULATOR_HOST")),
+            "Skipped: FIRESTORE_EMULATOR_HOST is not set.");
+
+        var db = await new FirestoreDbBuilder
+        {
+            ProjectId = "hobio-test-edge",
+            EmulatorDetection = Google.Api.Gax.EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+
+        var jobId = Guid.NewGuid();
+        var docRef = db.Collection("ReportJobs").Document(jobId.ToString());
+        var job = new ReportJob
+        {
+            JobId = jobId,
+            UserId = "user-123",
+            Year = 2024,
+            Sources = new List<string> { "Steam" },
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Status = "Completed",
+            StorageUrl = null   // ← no URL
+        };
+        await docRef.SetAsync(job);
+
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        var storageService = Substitute.For<hobio.api.Services.IStorageService>();
+
+        // Act
+        var result = await ReportHandler.GetReportStatus(jobId, db, storageService, logger);
+
+        // Assert
+        var ok = Assert.IsType<Ok<ReportStatusResponse>>(result);
+        Assert.Equal(jobId, ok.Value!.JobId);
+        Assert.Equal("Completed", ok.Value.Status);
+        Assert.Null(ok.Value.DownloadUrl);
+        await storageService.DidNotReceive().GetSignedDownloadUrlAsync(Arg.Any<string>(), Arg.Any<TimeSpan>());
+
+        // clean up
+        await docRef.DeleteAsync();
+    }
+
+    /// <summary>
+    /// When the job's Status is NOT "Completed" (e.g. "Pending"),
+    /// the handler must skip signed-URL generation and return Ok with null DownloadUrl.
+    /// </summary>
+    [Fact]
+    public async Task GetReportStatus_PendingJob_ReturnsOkWithNullDownloadUrl()
+    {
+        Skip.If(
+            string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FIRESTORE_EMULATOR_HOST")),
+            "Skipped: FIRESTORE_EMULATOR_HOST is not set.");
+
+        var db = await new FirestoreDbBuilder
+        {
+            ProjectId = "hobio-test-edge",
+            EmulatorDetection = Google.Api.Gax.EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+
+        var jobId = Guid.NewGuid();
+        var docRef = db.Collection("ReportJobs").Document(jobId.ToString());
+        var job = new ReportJob
+        {
+            JobId = jobId,
+            UserId = "user-123",
+            Year = 2024,
+            Sources = new List<string> { "Steam" },
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Status = "Pending",
+            StorageUrl = null
+        };
+        await docRef.SetAsync(job);
+
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        var storageService = Substitute.For<hobio.api.Services.IStorageService>();
+
+        var result = await ReportHandler.GetReportStatus(jobId, db, storageService, logger);
+
+        var ok = Assert.IsType<Ok<ReportStatusResponse>>(result);
+        Assert.Equal("Pending", ok.Value!.Status);
+        Assert.Null(ok.Value.DownloadUrl);
+        await storageService.DidNotReceive().GetSignedDownloadUrlAsync(Arg.Any<string>(), Arg.Any<TimeSpan>());
+
+        await docRef.DeleteAsync();
+    }
+
+    /// <summary>
+    /// When the signed-URL generation throws, the handler swallows the exception,
+    /// logs a warning, and returns Ok with a null DownloadUrl (graceful degradation).
+    /// </summary>
+    [Fact]
+    public async Task GetReportStatus_SignedUrlGenerationFails_ReturnsOkWithNullDownloadUrl()
+    {
+        Skip.If(
+            string.IsNullOrEmpty(Environment.GetEnvironmentVariable("FIRESTORE_EMULATOR_HOST")),
+            "Skipped: FIRESTORE_EMULATOR_HOST is not set.");
+
+        var db = await new FirestoreDbBuilder
+        {
+            ProjectId = "hobio-test-edge",
+            EmulatorDetection = Google.Api.Gax.EmulatorDetection.EmulatorOnly
+        }.BuildAsync();
+
+        var jobId = Guid.NewGuid();
+        var docRef = db.Collection("ReportJobs").Document(jobId.ToString());
+        var job = new ReportJob
+        {
+            JobId = jobId,
+            UserId = "user-123",
+            Year = 2024,
+            Sources = new List<string> { "Steam" },
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            Status = "Completed",
+            StorageUrl = "https://storage.example.com/report.pdf"
+        };
+        await docRef.SetAsync(job);
+
+        var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        var storageService = Substitute.For<hobio.api.Services.IStorageService>();
+        storageService
+            .GetSignedDownloadUrlAsync(Arg.Any<string>(), Arg.Any<TimeSpan>())
+            .ThrowsAsync(new InvalidOperationException("Signing failed"));
+
+        var result = await ReportHandler.GetReportStatus(jobId, db, storageService, logger);
+
+        var ok = Assert.IsType<Ok<ReportStatusResponse>>(result);
+        Assert.Equal("Completed", ok.Value!.Status);
+        Assert.Null(ok.Value.DownloadUrl);   // gracefully degraded
+
+        await docRef.DeleteAsync();
+    }
+}

--- a/tests/Handlers/ReportHandlerEdgeCaseTests.cs
+++ b/tests/Handlers/ReportHandlerEdgeCaseTests.cs
@@ -50,7 +50,7 @@ public class ReportHandlerEdgeCaseTests
     /// the handler must NOT call GetSignedDownloadUrlAsync and should return
     /// Ok with a null DownloadUrl.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task GetReportStatus_CompletedJobWithNullStorageUrl_ReturnsOkWithNullDownloadUrl()
     {
         // Arrange – seed a "Completed" job that has no StorageUrl yet
@@ -103,7 +103,7 @@ public class ReportHandlerEdgeCaseTests
     /// When the job's Status is NOT "Completed" (e.g. "Pending"),
     /// the handler must skip signed-URL generation and return Ok with null DownloadUrl.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task GetReportStatus_PendingJob_ReturnsOkWithNullDownloadUrl()
     {
         Skip.If(
@@ -148,7 +148,7 @@ public class ReportHandlerEdgeCaseTests
     /// When the signed-URL generation throws, the handler swallows the exception,
     /// logs a warning, and returns Ok with a null DownloadUrl (graceful degradation).
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task GetReportStatus_SignedUrlGenerationFails_ReturnsOkWithNullDownloadUrl()
     {
         Skip.If(

--- a/tests/Handlers/ReportHandlerFirestoreTests.cs
+++ b/tests/Handlers/ReportHandlerFirestoreTests.cs
@@ -129,7 +129,8 @@ public class ReportHandlerFirestoreTests : IAsyncLifetime
         // Act
         var logger = Substitute.For<ILogger<hobio.api.Program>>();
         var storageService = Substitute.For<hobio.api.Services.IStorageService>();
-        storageService.GetSignedDownloadUrlAsync("https://storage.example.com/report.pdf", Arg.Any<TimeSpan>())
+        // The handler parses the StorageUrl and passes only the object name (AbsolutePath minus leading '/') to GetSignedDownloadUrlAsync.
+        storageService.GetSignedDownloadUrlAsync("storage.example.com/report.pdf", Arg.Any<TimeSpan>())
             .Returns(Task.FromResult("https://storage.example.com/signed-url.pdf"));
 
         var result = await ReportHandler.GetReportStatus(jobId, Db, storageService, logger);

--- a/tests/Handlers/ReportHandlerFirestoreTests.cs
+++ b/tests/Handlers/ReportHandlerFirestoreTests.cs
@@ -129,8 +129,8 @@ public class ReportHandlerFirestoreTests : IAsyncLifetime
         // Act
         var logger = Substitute.For<ILogger<hobio.api.Program>>();
         var storageService = Substitute.For<hobio.api.Services.IStorageService>();
-        // The handler parses the StorageUrl and passes only the object name (AbsolutePath minus leading '/') to GetSignedDownloadUrlAsync.
-        storageService.GetSignedDownloadUrlAsync("storage.example.com/report.pdf", Arg.Any<TimeSpan>())
+        // The handler extracts Uri.AbsolutePath ("/report.pdf") then TrimStart('/') → "report.pdf"
+        storageService.GetSignedDownloadUrlAsync("report.pdf", Arg.Any<TimeSpan>())
             .Returns(Task.FromResult("https://storage.example.com/signed-url.pdf"));
 
         var result = await ReportHandler.GetReportStatus(jobId, Db, storageService, logger);

--- a/tests/Handlers/ReportHandlerFirestoreTests.cs
+++ b/tests/Handlers/ReportHandlerFirestoreTests.cs
@@ -128,13 +128,17 @@ public class ReportHandlerFirestoreTests : IAsyncLifetime
 
         // Act
         var logger = Substitute.For<ILogger<hobio.api.Program>>();
-        var result = await ReportHandler.GetReportStatus(jobId, Db, logger);
+        var storageService = Substitute.For<hobio.api.Services.IStorageService>();
+        storageService.GetSignedDownloadUrlAsync("https://storage.example.com/report.pdf", Arg.Any<TimeSpan>())
+            .Returns(Task.FromResult("https://storage.example.com/signed-url.pdf"));
+
+        var result = await ReportHandler.GetReportStatus(jobId, Db, storageService, logger);
 
         // Assert
         var ok = Assert.IsType<Ok<ReportStatusResponse>>(result);
         Assert.Equal(jobId, ok.Value!.JobId);
         Assert.Equal("Completed", ok.Value.Status);
-        Assert.Equal("https://storage.example.com/report.pdf", ok.Value.DownloadUrl);
+        Assert.Equal("https://storage.example.com/signed-url.pdf", ok.Value.DownloadUrl);
 
         // clean up
         await docRef.DeleteAsync();
@@ -151,7 +155,8 @@ public class ReportHandlerFirestoreTests : IAsyncLifetime
 
         // Act
         var logger = Substitute.For<ILogger<hobio.api.Program>>();
-        var result = await ReportHandler.GetReportStatus(missingJobId, Db, logger);
+        var storageService = Substitute.For<hobio.api.Services.IStorageService>();
+        var result = await ReportHandler.GetReportStatus(missingJobId, Db, storageService, logger);
 
         // Assert
         Assert.IsType<NotFound>(result);

--- a/tests/Handlers/ReportHandlerTests.cs
+++ b/tests/Handlers/ReportHandlerTests.cs
@@ -57,9 +57,10 @@ public class ReportHandlerTests
     {
         // Arrange
         var logger = Substitute.For<ILogger<hobio.api.Program>>();
+        var storageService = Substitute.For<hobio.api.Services.IStorageService>();
 
         // Act
-        var result = await ReportHandler.GetReportStatus(Guid.NewGuid(), null, logger);
+        var result = await ReportHandler.GetReportStatus(Guid.NewGuid(), null, storageService, logger);
 
         // Assert
         var problem = Assert.IsType<ProblemHttpResult>(result);

--- a/tests/Models/GuidConverterTests.cs
+++ b/tests/Models/GuidConverterTests.cs
@@ -1,0 +1,155 @@
+using hobio.shared.Models;
+
+namespace hobio.tests.Models;
+
+/// <summary>
+/// Unit tests for <see cref="GuidConverter"/> and the <see cref="ReportJob"/> model.
+/// These are pure unit tests — no external dependencies.
+/// </summary>
+public class GuidConverterTests
+{
+    private readonly GuidConverter _converter = new();
+
+    // -------------------------------------------------------------------------
+    // ToFirestore
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ToFirestore_ValidGuid_ReturnsStringRepresentation()
+    {
+        var guid = Guid.NewGuid();
+        var result = _converter.ToFirestore(guid);
+        Assert.Equal(guid.ToString(), result);
+    }
+
+    [Fact]
+    public void ToFirestore_EmptyGuid_ReturnsEmptyGuidString()
+    {
+        var result = _converter.ToFirestore(Guid.Empty);
+        Assert.Equal(Guid.Empty.ToString(), result);
+    }
+
+    // -------------------------------------------------------------------------
+    // FromFirestore
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void FromFirestore_ValidGuidString_ReturnsGuid()
+    {
+        var guid = Guid.NewGuid();
+        var result = _converter.FromFirestore(guid.ToString());
+        Assert.Equal(guid, result);
+    }
+
+    [Fact]
+    public void FromFirestore_EmptyGuidString_ReturnsEmptyGuid()
+    {
+        var result = _converter.FromFirestore(Guid.Empty.ToString());
+        Assert.Equal(Guid.Empty, result);
+    }
+
+    [Fact]
+    public void FromFirestore_InvalidValue_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => _converter.FromFirestore("not-a-guid"));
+    }
+
+    [Fact]
+    public void FromFirestore_NonStringValue_ThrowsArgumentException()
+    {
+        // Passing an int (non-string) should hit the default arm and throw
+        Assert.Throws<ArgumentException>(() => _converter.FromFirestore(42));
+    }
+
+    // -------------------------------------------------------------------------
+    // ReportJob model default values
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ReportJob_DefaultValues_AreCorrect()
+    {
+        var job = new ReportJob();
+
+        Assert.NotEqual(Guid.Empty, job.JobId);
+        Assert.Equal(string.Empty, job.UserId);
+        Assert.Equal("Pending", job.Status);
+        Assert.Null(job.StorageUrl);
+        Assert.Null(job.Title);
+        Assert.NotEmpty(job.Sources is { Count: 0 } ? new[] { "ok" } : Array.Empty<string>()); // Sources defaults to []
+        Assert.Equal(DateTime.UtcNow.Year, job.Year);
+    }
+
+    [Fact]
+    public void ReportJob_PropertyAssignment_Works()
+    {
+        var jobId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        var job = new ReportJob
+        {
+            JobId = jobId,
+            UserId = "test-user",
+            Status = "Completed",
+            StorageUrl = "https://bucket/file.pdf",
+            Title = "Annual Report",
+            Sources = new List<string> { "Steam", "LastFm" },
+            Year = 2023,
+            Month = 12,
+            Day = 31,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        Assert.Equal(jobId, job.JobId);
+        Assert.Equal("test-user", job.UserId);
+        Assert.Equal("Completed", job.Status);
+        Assert.Equal("https://bucket/file.pdf", job.StorageUrl);
+        Assert.Equal("Annual Report", job.Title);
+        Assert.Equal(new List<string> { "Steam", "LastFm" }, job.Sources);
+        Assert.Equal(2023, job.Year);
+        Assert.Equal(12, job.Month);
+        Assert.Equal(31, job.Day);
+        Assert.Equal(now, job.CreatedAt);
+        Assert.Equal(now, job.UpdatedAt);
+    }
+
+    // -------------------------------------------------------------------------
+    // Record models
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ReportRequest_RecordEquality_Works()
+    {
+        var r1 = new ReportRequest(2024, new List<string> { "Steam" });
+        var r2 = new ReportRequest(2024, new List<string> { "Steam" });
+        // Records use structural equality
+        Assert.Equal(r1.Year, r2.Year);
+        Assert.Equal(r1.Sources, r2.Sources);
+    }
+
+    [Fact]
+    public void ReportResponse_RecordHoldsJobId()
+    {
+        var id = Guid.NewGuid();
+        var r = new ReportResponse(id);
+        Assert.Equal(id, r.JobId);
+    }
+
+    [Fact]
+    public void ReportStatusResponse_RecordProperties_AreAccessible()
+    {
+        var id = Guid.NewGuid();
+        var r = new ReportStatusResponse(id, "Completed", "https://url", null);
+        Assert.Equal(id, r.JobId);
+        Assert.Equal("Completed", r.Status);
+        Assert.Equal("https://url", r.DownloadUrl);
+        Assert.Null(r.ErrorMessage);
+    }
+
+    [Fact]
+    public void ReportStatusResponse_WithNullDownloadUrl_IsValid()
+    {
+        var r = new ReportStatusResponse(Guid.NewGuid(), "Pending", null, null);
+        Assert.Null(r.DownloadUrl);
+    }
+}

--- a/tests/PdfLayouts/ReportDocumentTests.cs
+++ b/tests/PdfLayouts/ReportDocumentTests.cs
@@ -1,0 +1,66 @@
+using hobio.shared.Models;
+using hobio.worker.PdfLayouts;
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+
+namespace hobio.tests.PdfLayouts;
+
+/// <summary>
+/// Unit tests for <see cref="ReportDocument"/>.
+/// GeneratePdf() is a QuestPDF extension method available on IDocument via QuestPDF.Fluent.
+/// QuestPDF Community licence is set in the constructor.
+/// </summary>
+public class ReportDocumentTests
+{
+    public ReportDocumentTests()
+    {
+        QuestPDF.Settings.License = LicenseType.Community;
+    }
+
+    private static ReportJob MakeJob(int year = 2024, List<string>? sources = null) => new()
+    {
+        JobId = Guid.NewGuid(),
+        UserId = "test-user",
+        Year = year,
+        Sources = sources ?? new List<string> { "Steam", "LastFm" },
+        Status = "Pending"
+    };
+
+    [Fact]
+    public void GeneratePdf_ReturnsNonEmptyByteArray()
+    {
+        IDocument doc = new ReportDocument(MakeJob());
+        var bytes = doc.GeneratePdf();
+        Assert.NotNull(bytes);
+        Assert.True(bytes.Length > 0);
+    }
+
+    [Fact]
+    public void GeneratePdf_OutputStartsWithPdfMagicBytes()
+    {
+        IDocument doc = new ReportDocument(MakeJob());
+        var bytes = doc.GeneratePdf();
+        // PDF files always start with %PDF
+        Assert.Equal((byte)'%', bytes[0]);
+        Assert.Equal((byte)'P', bytes[1]);
+        Assert.Equal((byte)'D', bytes[2]);
+        Assert.Equal((byte)'F', bytes[3]);
+    }
+
+    [Fact]
+    public void GeneratePdf_WithNoSources_StillProducesValidPdf()
+    {
+        IDocument doc = new ReportDocument(MakeJob(sources: new List<string>()));
+        var bytes = doc.GeneratePdf();
+        Assert.True(bytes.Length > 0);
+    }
+
+    [Fact]
+    public void GeneratePdf_WithManySources_StillProducesValidPdf()
+    {
+        var sources = Enumerable.Range(1, 20).Select(i => $"Source{i}").ToList();
+        IDocument doc = new ReportDocument(MakeJob(sources: sources));
+        var bytes = doc.GeneratePdf();
+        Assert.True(bytes.Length > 0);
+    }
+}

--- a/tests/Services/StorageServiceTests.cs
+++ b/tests/Services/StorageServiceTests.cs
@@ -1,0 +1,40 @@
+using Google.Apis.Auth.OAuth2;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+using NSubstitute;
+using hobio.api.Services;
+
+namespace hobio.tests.Services;
+
+public class StorageServiceTests
+{
+    [Fact]
+    public void Constructor_WithMissingBucketName_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var config = Substitute.For<IConfiguration>();
+        config["REPORTS_BUCKET_NAME"].Returns((string?)null);
+
+        var credential = GoogleCredential.FromAccessToken("fake-token");
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentNullException>(() => new StorageService(config, credential));
+        Assert.Contains("REPORTS_BUCKET_NAME not set", ex.Message);
+    }
+
+    [Fact]
+    public void Constructor_WithValidBucketName_Succeeds()
+    {
+        // Arrange
+        var config = Substitute.For<IConfiguration>();
+        config["REPORTS_BUCKET_NAME"].Returns("test-bucket");
+
+        var credential = GoogleCredential.FromAccessToken("fake-token");
+
+        // Act
+        var service = new StorageService(config, credential);
+
+        // Assert
+        Assert.NotNull(service);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed report downloads are now delivered as time-limited signed URLs (15-minute expiration).
  * Reports that are not completed do not expose a download link.
  * API deployment is updated to include configuration for the reports storage bucket.

* **Tests**
  * Updated tests to validate signed URL generation and the conditional download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->